### PR TITLE
Add GitHub Actions badge and improve test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10.13.1
+          run_install: false
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 The smart way to write your commit messages using [Conventional Commits](https://www.conventionalcommits.org/).
 
+![Test](https://github.com/ragnarok22/gsmart/actions/workflows/test.yml/badge.svg)
 ![NPM Downloads](https://img.shields.io/npm/dm/gsmart)
 ![NPM Version](https://img.shields.io/npm/v/gsmart)
 ![NPM License](https://img.shields.io/npm/l/gsmart)


### PR DESCRIPTION
## Summary
- run tests on Node.js 20 and 22 via GitHub Actions
- show the workflow badge in the README

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_687f897315e0832c8666410525024df6