### PR TITLE
docs(readme): align ai model references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ The CLI follows a command pattern where:
 ### AI Provider System
 
 - Multiple AI providers supported through unified `AIBuilder` class
-- Each provider uses different models (GPT-4o, Claude, Gemini, Mistral, etc.)
+- Each provider uses different models (gpt-5-codex, claude-3-5-haiku-latest, gemini-2.0-flash, mistral-large-latest, firefunction-v1, radiance)
 - Providers configured with specific base URLs and model names
 - API keys stored securely using the conf package
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Commands:
 
 | Provider         | Model                                                                             | Get API Key                                                  |
 | ---------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **OpenAI**       | [GPT-4o](https://platform.openai.com/docs/models/gpt-4o)                          | [Get Key](https://platform.openai.com/api-keys)              |
+| **OpenAI**       | [GPT-5 Codex](https://platform.openai.com/docs/models/gpt-5-codex)                | [Get Key](https://platform.openai.com/api-keys)              |
 | **Anthropic**    | [Claude](https://www.anthropic.com/claude)                                        | [Get Key](https://console.anthropic.com/settings/keys)       |
 | **Google**       | [Gemini 2.0 Flash](https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash) | [Get Key](https://console.cloud.google.com/apis/credentials) |
 | **Mistral**      | [Mistral Large](https://mistral.ai/technology/#models)                            | [Get Key](https://console.mistral.ai/api-keys/)              |


### PR DESCRIPTION
### Motivation
- Ensure documentation matches the actual default AI model configured in the codebase.
- Remove confusion between README/CLAUDE guidance and `src/utils/ai.ts` provider configuration.
- Keep provider model names consistent across docs and implementation for accurate onboarding.

### Description
- Updated the OpenAI entry in `README.md` provider table to `GPT-5 Codex` and its link to `gpt-5-codex`.
- Updated `CLAUDE.md` model list to reflect the models used in `src/utils/ai.ts` (e.g. `gpt-5-codex`, `claude-3-5-haiku-latest`, `gemini-2.0-flash`, `mistral-large-latest`, `firefunction-v1`, `radiance`).
- Modified files: `README.md`, `CLAUDE.md` to maintain documentation parity with implementation.

### Testing
- No automated tests were executed because this change only touches documentation files.
- Linting and test suites were not run as part of this docs-only update.
- CI checks (if configured) will run on merge to validate build and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a69e9d058832ca0b42c6f6d160082)