### PR TITLE
fix(utils): handle git rename/copy score codes (R100/C100)

### DIFF
--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -12,6 +12,7 @@ import {
   getGitChanges,
   commitChanges,
   getGitStatus,
+  parseGitStatusEntries,
   stageFile,
   getGitInfo,
 } from "../src/utils/git.ts";
@@ -149,6 +150,20 @@ test("getGitStatus handles malformed status lines", async () => {
     process.chdir(cwd);
     rmSync(repo, { recursive: true, force: true });
   }
+});
+
+test("parseGitStatusEntries handles rename/copy scores", () => {
+  const statusOutput =
+    "R100 renamed.txt\0original.txt\0C100 copied.txt\0source.txt\0";
+  const parsed = parseGitStatusEntries(statusOutput);
+
+  assert.equal(parsed.length, 2);
+  assert.equal(parsed[0].status, "R100");
+  assert.equal(parsed[0].file_path, "renamed.txt");
+  assert.equal(parsed[0].original_path, "original.txt");
+  assert.equal(parsed[1].status, "C100");
+  assert.equal(parsed[1].file_path, "copied.txt");
+  assert.equal(parsed[1].original_path, "source.txt");
 });
 
 test("git commands work in non-git directory", async () => {


### PR DESCRIPTION
### Motivation

- `git status --porcelain -z` can emit rename/copy codes with scores like `R100`/`C100`, which the previous parser (expecting exactly 2 status chars) did not fully capture.
- The rename/copy secondary-path detection relied on trimming which could misinterpret multi-character status codes.
- Add regression coverage to ensure these score codes are parsed and preserved for downstream logic and display.

### Description

- Added `parseGitStatusEntries` to parse porcelain `--porcelain -z` output with a regex that accepts 2–4 status characters (`/^(.{2,4})\s+(.+)$/`) and preserve the full status string in `status`.
- Updated `getGitStatus` to delegate to `parseGitStatusEntries` and return the parsed `GitStatus[]`.
- Normalized XY-code logic by extracting `statusCode.slice(0, 2)` for XY comparisons and updated `needsSecondaryPath` to inspect the first non-space status character via `statusCode.replace(/\s/g, "")[0]`.
- Added a regression test `parseGitStatusEntries handles rename/copy scores` to `test/git.test.ts` that asserts parsing of `R100` and `C100` entries and their original paths.

### Testing

- Ran the focused test file with `pnpm test -- test/git.test.ts` which executed the updated tests.
- The run completed successfully with `22` tests passing and `0` failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6a190530832cb2c63b3757c8b14b)