### PR TITLE
chore(build): drop node 18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,7 @@ As of v0.9.0, GSmart supports the following AI providers:
 
 GSmart is built with modern technologies:
 
-- Node.js 18+ with ESM support
+- Node.js 20+ with ESM support
 - TypeScript for type safety
 - Commander.js for CLI framework
 - AI SDK for provider integrations

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Commands:
 
 ### Requirements
 
-- Node.js 18+ with ESM support
+- Node.js 20+ with ESM support
 - pnpm (recommended) or npm
 
 ### Scripts

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   ],
   "author": "Reinier Hernández <sasuke.reinier@gmail.com>",
   "license": "GPL-3.0-only",
+  "engines": {
+    "node": ">=20"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
### Motivation
- Move the project to a newer Node.js runtime requirement and drop Node 18 support.
- Make the minimum supported Node version explicit in package metadata to avoid ambiguity for consumers and CI.
- Ensure documentation reflects the updated runtime requirement so contributors and users know the minimum environment.

### Description
- Add an `engines` field to `package.json` specifying `"node": ">=20"`.
- Update `README.md` to mention `Node.js 20+` as the development/runtime requirement.
- Update `CHANGELOG.md` to replace references to `Node.js 18+` with `Node.js 20+`.
- These changes are configuration and documentation only and do not modify runtime code.

### Testing
- No automated tests were run for this PR because it only updates docs and package metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6fcc94a4832c8b58a218158bc369)