### PR TITLE
test(setup-env): add tests for GSMART_CONFIG_DIR behavior

### DIFF
--- a/test/setup-env.test.ts
+++ b/test/setup-env.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const importSetupEnv = async () => {
+  const cacheBust = Date.now().toString(36);
+  return import(`../test-support/setup-env.ts?${cacheBust}`);
+};
+
+test("setup-env sets GSMART_CONFIG_DIR when unset", async () => {
+  const originalEnv = process.env.GSMART_CONFIG_DIR;
+  delete process.env.GSMART_CONFIG_DIR;
+
+  try {
+    await importSetupEnv();
+
+    assert.ok(process.env.GSMART_CONFIG_DIR);
+    assert.ok(existsSync(process.env.GSMART_CONFIG_DIR));
+  } finally {
+    if (process.env.GSMART_CONFIG_DIR) {
+      rmSync(process.env.GSMART_CONFIG_DIR, { recursive: true, force: true });
+    }
+    if (originalEnv) {
+      process.env.GSMART_CONFIG_DIR = originalEnv;
+    } else {
+      delete process.env.GSMART_CONFIG_DIR;
+    }
+  }
+});
+
+test("setup-env preserves GSMART_CONFIG_DIR when set", async () => {
+  const originalEnv = process.env.GSMART_CONFIG_DIR;
+  const presetDir = mkdtempSync(join(tmpdir(), "gsmart-preset-"));
+  process.env.GSMART_CONFIG_DIR = presetDir;
+
+  try {
+    await importSetupEnv();
+
+    assert.equal(process.env.GSMART_CONFIG_DIR, presetDir);
+  } finally {
+    rmSync(presetDir, { recursive: true, force: true });
+    if (originalEnv) {
+      process.env.GSMART_CONFIG_DIR = originalEnv;
+    } else {
+      delete process.env.GSMART_CONFIG_DIR;
+    }
+  }
+});


### PR DESCRIPTION
### Motivation

- Add unit coverage for the test bootstrap `test-support/setup-env.ts` to ensure `GSMART_CONFIG_DIR` is correctly defaulted when unset and preserved when already set, preventing environment-related test flakiness.

### Description

- Add `test/setup-env.test.ts` which dynamically imports the setup file to avoid module cache and test initialization side effects.  
- Add a test that deletes `process.env.GSMART_CONFIG_DIR`, imports the setup, and asserts a directory was created and the env var is set.  
- Add a test that presets `process.env.GSMART_CONFIG_DIR`, imports the setup, and asserts the value is preserved.  
- Both tests clean up any created temporary directories and restore the original environment variable after running.

### Testing

- No automated test run was executed as part of this change; the new tests were added under `test/setup-env.test.ts` and can be run with `pnpm test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679a2e43b0832cbb7a51e90689d9ee)