### PR TITLE
test(utils): expand holiday and version-check test coverage

### DIFF
--- a/test/holiday.test.ts
+++ b/test/holiday.test.ts
@@ -1,6 +1,55 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getHolidayForDate } from "../src/utils/holiday.ts";
+import {
+  getHolidayForDate,
+  showHolidayMessage,
+} from "../src/utils/holiday.ts";
+
+const captureConsoleLog = (fn: () => void): string[] => {
+  const originalLog = console.log;
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((arg) => String(arg)).join(" "));
+  };
+  try {
+    fn();
+    return logs;
+  } finally {
+    console.log = originalLog;
+  }
+};
+
+const withMockedDate = (date: Date, fn: () => void): void => {
+  const RealDate = Date;
+  global.Date = class extends RealDate {
+    constructor(...args: ConstructorParameters<typeof Date>) {
+      if (args.length === 0) {
+        return new RealDate(date);
+      }
+      return new RealDate(...args);
+    }
+
+    static now(): number {
+      return date.getTime();
+    }
+
+    static parse(dateString: string): number {
+      return RealDate.parse(dateString);
+    }
+
+    static UTC(
+      ...args: Parameters<typeof Date.UTC>
+    ): ReturnType<typeof Date.UTC> {
+      return RealDate.UTC(...args);
+    }
+  } as DateConstructor;
+
+  try {
+    fn();
+  } finally {
+    global.Date = RealDate;
+  }
+};
 
 test("getHolidayForDate detects Easter Sunday by year", () => {
   assert.equal(getHolidayForDate(new Date(2024, 2, 31)), "easter");
@@ -23,4 +72,34 @@ test("getHolidayForDate detects fixed-date holidays", () => {
 
 test("getHolidayForDate returns null for non-holiday dates", () => {
   assert.equal(getHolidayForDate(new Date(2024, 6, 10)), null);
+});
+
+test("showHolidayMessage prints a Christmas greeting", () => {
+  const logs = captureConsoleLog(() => {
+    withMockedDate(new Date(2024, 11, 24), () => {
+      showHolidayMessage();
+    });
+  });
+
+  assert(logs.some((line) => line.includes("H A P P Y   H O L I D A Y S")));
+});
+
+test("showHolidayMessage prints a New Year greeting for New Year's Eve", () => {
+  const logs = captureConsoleLog(() => {
+    withMockedDate(new Date(2024, 11, 31), () => {
+      showHolidayMessage();
+    });
+  });
+
+  assert(logs.some((line) => line.includes("H A P P Y   N E W   Y E A R")));
+});
+
+test("showHolidayMessage prints nothing on non-holidays", () => {
+  const logs = captureConsoleLog(() => {
+    withMockedDate(new Date(2024, 6, 10), () => {
+      showHolidayMessage();
+    });
+  });
+
+  assert.equal(logs.length, 0);
 });


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for UI-facing utilities in `src/utils` by exercising holiday messaging and update-notification code paths.
- Verify that `showHolidayMessage` prints the expected greetings on specific dates and that `checkForUpdates` formats output when updates are found or suppresses output when none are available.

### Description

- Added console-capture helper `captureConsoleLog` and a date-mocking helper `withMockedDate` to `test/holiday.test.ts` and used them to assert `showHolidayMessage` output for Christmas, New Year’s Eve, and non-holiday dates while retaining existing `getHolidayForDate` assertions. 
- Added `captureConsoleLogAsync` and `mock.module`-based scenarios to `test/version-check.test.ts` to stub `update-notifier` and assert the logged update banner when `update` is present and no logging when `update` is `null`.
- Modified `test/holiday.test.ts` and `test/version-check.test.ts` to import and exercise `showHolidayMessage` and `checkForUpdates` respectively.

### Testing

- No automated test suite was executed as part of this change; the PR only adds and expands unit tests in `test/holiday.test.ts` and `test/version-check.test.ts` (no test runner results were produced during the rollout).
- New tests are written to run under the existing test runner using `node:test` and rely on `mock.module` where available for module-level mocking.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696799ea2e18832c8b91570e5ebc27b6)