### PR TITLE
test(utils): expand checkForUpdates coverage

### DIFF
--- a/test/version-check.test.ts
+++ b/test/version-check.test.ts
@@ -2,22 +2,7 @@ import "../test-support/setup-env";
 
 import test, { mock } from "node:test";
 import assert from "node:assert/strict";
-import { checkForUpdates } from "../src/utils/version-check.ts";
-
 // Mock console.log to capture output
-const captureConsoleLog = (fn: () => void): string[] => {
-  const originalLog = console.log;
-  const logs: string[] = [];
-  console.log = (...args: unknown[]) => {
-    logs.push(args.map((arg) => String(arg)).join(" "));
-  };
-  try {
-    fn();
-    return logs;
-  } finally {
-    console.log = originalLog;
-  }
-};
 
 const captureConsoleLogAsync = async (
   fn: () => Promise<void>,


### PR DESCRIPTION
### Motivation
- Improve unit coverage for `checkForUpdates` while avoiding real network calls to `update-notifier` so tests are deterministic.
- Assert the notifier is called with the expected package info and check interval, and preserve logging expectations for update/no-update cases.
- No user-facing behavior changes are introduced.

### Description
- Updated `test/version-check.test.ts` to mock `update-notifier` using `mock.module` and `mock.fn` and to import the module under test dynamically for isolated scenarios.
- Added a test that asserts `checkForUpdates` calls `update-notifier` once with `{ pkg, updateCheckInterval: 1000 * 60 * 60 * 24 }` and that no console output occurs when `update` is `null`.
- Converted previous synchronous validation tests to use the mocked notifier and async import, kept existing tests for update-available and update-none, and added guards to skip tests on Node versions where `mock.module` is unavailable.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679bfb13fc832caa312084d2f47a1a)