### PR TITLE
fix(config): guard raw-mode prompt input in non-tty environments

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -12,6 +12,19 @@ const readPromptInput = (
   initial: string = "",
 ): Promise<string | null> => {
   return new Promise((resolve) => {
+    const supportsRawMode =
+      process.stdin.isTTY && typeof process.stdin.setRawMode === "function";
+
+    if (!supportsRawMode) {
+      console.log(
+        chalk.yellow(
+          "Interactive prompt input is unavailable in this environment. Use --add-custom-prompt \"...\" to set a default prompt non-interactively.",
+        ),
+      );
+      resolve(initial.trim() || null);
+      return;
+    }
+
     let buffer = initial;
     let isPasted = !!initial;
     let inBracketedPaste = false;

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -18,7 +18,7 @@ const readPromptInput = (
     if (!supportsRawMode) {
       console.log(
         chalk.yellow(
-          "Interactive prompt input is unavailable in this environment. Use --add-custom-prompt \"...\" to set a default prompt non-interactively.",
+          'Interactive prompt input is unavailable in this environment. Use --add-custom-prompt "..." to set a default prompt non-interactively.',
         ),
       );
       resolve(initial.trim() || null);

--- a/test/config-command.test.ts
+++ b/test/config-command.test.ts
@@ -1,0 +1,109 @@
+import "../test-support/setup-env";
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import esmock from "esmock";
+
+test("config set does not crash in non-tty environments", async () => {
+  const originalIsTTY = process.stdin.isTTY;
+  const originalSetRawMode = process.stdin.setRawMode;
+  const logs: string[] = [];
+  const failures: string[] = [];
+  let setPromptCalled = false;
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: false,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdin, "setRawMode", {
+    value: undefined,
+    configurable: true,
+  });
+
+  const originalConsoleLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    const ConfigCommand = (
+      await esmock("../src/commands/config.ts", {
+        prompts: async () => ({ action: "set" }),
+        ora: () => ({
+          fail: (message: string) => failures.push(message),
+          succeed: () => undefined,
+          warn: () => undefined,
+        }),
+        "../src/utils/prompt-config.ts": {
+          getPrompt: () => "",
+          setPrompt: () => {
+            setPromptCalled = true;
+          },
+          clearPrompt: () => ({ cleared: false }),
+        },
+      })
+    ).default;
+
+    await ConfigCommand.action({});
+  } finally {
+    console.log = originalConsoleLog;
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      value: originalSetRawMode,
+      configurable: true,
+    });
+  }
+
+  assert.equal(setPromptCalled, false);
+  assert.equal(failures.length, 1);
+  assert.match(logs.join("\n"), /non-interactively/i);
+});
+
+test("config set in non-tty mode reuses existing prompt as fallback", async () => {
+  const originalIsTTY = process.stdin.isTTY;
+  const originalSetRawMode = process.stdin.setRawMode;
+  let savedPrompt = "";
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    value: false,
+    configurable: true,
+  });
+  Object.defineProperty(process.stdin, "setRawMode", {
+    value: undefined,
+    configurable: true,
+  });
+
+  try {
+    const ConfigCommand = (
+      await esmock("../src/commands/config.ts", {
+        prompts: async () => ({ action: "set" }),
+        ora: () => ({
+          fail: () => undefined,
+          succeed: () => undefined,
+          warn: () => undefined,
+        }),
+        "../src/utils/prompt-config.ts": {
+          getPrompt: () => "keep scope concise",
+          setPrompt: (prompt: string) => {
+            savedPrompt = prompt;
+          },
+          clearPrompt: () => ({ cleared: false }),
+        },
+      })
+    ).default;
+
+    await ConfigCommand.action({});
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      value: originalSetRawMode,
+      configurable: true,
+    });
+  }
+
+  assert.equal(savedPrompt, "keep scope concise");
+});


### PR DESCRIPTION
### Motivation
- Prevent crashes when `readPromptInput` calls `process.stdin.setRawMode` in non-interactive or piped environments where raw mode is unavailable.
- Provide a clear, safe fallback so `gsmart config` behaves predictably in CI/non-TTY contexts and guides users to a non-interactive option.

### Description
- Added a raw-mode capability guard in `readPromptInput` that checks `process.stdin.isTTY` and `typeof process.stdin.setRawMode === "function"` before enabling raw mode and otherwise logs guidance and returns a safe fallback (`initial` trimmed) instead of throwing.
- Preserved existing interactive behavior (bracketed paste handling and raw-mode input) for TTY terminals by applying the guard before any `setRawMode` calls.
- Added unit tests in `test/config-command.test.ts` to assert that `config set` does not crash in non-TTY mode and that existing prompts are reused as a fallback.

### Testing
- Ran `pnpm test -- test/config-command.test.ts` and the new tests passed (no failures).
- Ran the project test suite (`pnpm test`) which completed with all tests passing (288 passed, 0 failed).
- Ran lint (`pnpm run lint`) which completed successfully with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa86eba9c832c9f49e883c162943e)